### PR TITLE
New optional parameter to specify node version

### DIFF
--- a/jobs/build.yml
+++ b/jobs/build.yml
@@ -10,12 +10,22 @@ parameters:
   working_directory: ''
   # package manager
   package_manager: 'npm'
+  # node version
+  node_version: ''
 
 jobs:
 - job: ${{ parameters.job_name }}
   displayName: ${{ parameters.display_name }}
   pool: ${{ parameters.pool }}
   steps:
+  ##########################################
+  ## specify which node version to use
+  ##########################################
+  - task: UseNode@1
+    displayName: Set up Node.js environment ${{ parameters.node_version }}
+    inputs:
+      version: ${{ parameters.node_version }}
+    condition: ne('${{ parameters.node_version }}', '')
   ##########################################
   ## install dependencies using specified 
   ##    package manager

--- a/jobs/deploy.yml
+++ b/jobs/deploy.yml
@@ -46,7 +46,6 @@ jobs:
           inputs:
             buildType: current
             artifactName: spfx-package
-            path: "$(Pipeline.Workspace)/spfx-package"
         ##########################################
         ## determine name of generated *.sppkg
         ##########################################

--- a/jobs/deploy.yml
+++ b/jobs/deploy.yml
@@ -46,6 +46,7 @@ jobs:
           inputs:
             buildType: current
             artifactName: spfx-package
+            path: "$(Pipeline.Workspace)/spfx-package"
         ##########################################
         ## determine name of generated *.sppkg
         ##########################################

--- a/jobs/test.yml
+++ b/jobs/test.yml
@@ -10,6 +10,8 @@ parameters:
   working_directory: ''
   # package manager
   package_manager: 'npm'
+  # node version
+  node_version: ''
 
 jobs:
 - job: ${{ parameters.job_name }}
@@ -17,6 +19,14 @@ jobs:
   pool:
     vmImage: ubuntu-latest
   steps:
+  ##########################################
+  ## specify which node version to use
+  ##########################################
+  - task: UseNode@1
+    displayName: Set up Node.js environment ${{ parameters.node_version }}
+    inputs:
+      version: ${{ parameters.node_version }}
+    condition: ne('${{ parameters.node_version }}', '')  
   ##########################################
   ## install dependencies using specified 
   ##    package manager

--- a/sample/azure-pipelines.yml
+++ b/sample/azure-pipelines.yml
@@ -20,6 +20,7 @@ stages:
     - template: jobs/build.yml@azure-pipelines-spfx-templates
       parameters:
         working_directory: sample
+        node_version: 10.x
 - stage: Test
   dependsOn: []
   jobs:
@@ -27,6 +28,7 @@ stages:
       parameters:
         working_directory: sample
         package_manager: yarn
+        node_version: 10.x
 - stage: Deploy_Dev
   dependsOn:
     - Build


### PR DESCRIPTION
With SPFx 1.9.1 build and test fails due to node 12.x not being supported by node-sass@4.9.3 that is required by @microsoft/gulp-core-build-sass.

Being able to specify to run against node version 10.x allows these jobs to complete successfully.